### PR TITLE
fix migrate-storyblok-components, change dir rather than copy files

### DIFF
--- a/cli/migrateStoryblokComponents.js
+++ b/cli/migrateStoryblokComponents.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
+require('dotenv').config();
+
 const fs = require('fs');
 const { exec } = require('child_process');
-const rimraf = require('rimraf');
 
-const files = fs.readdirSync('node_modules/mui-storyblok/storyblok');
+const files = fs.readdirSync('node_modules/mui-storyblok/dist/storyblok');
 const fileNames = files.map(file => file.replace('.js', '')).filter(x => x != null).join();
 const cmd = `npx storyblok-migrate --component-migrations --components ${fileNames}`;
 
@@ -22,27 +23,9 @@ const asyncCmd = (command) => {
   });
 };
 
-const addDirToRoot = (projectRoot, dir) => {
-  exec(`cp -R ${projectRoot}/node_modules/mui-storyblok/dist/${dir} ${projectRoot}/${dir}`, (error, stdout, stderr) => {
-    if (error) {
-      console.warn(error);
-    }
-    console.log(stdout || stderr);
-  });
-};
-
-const removeDirFromRoot = (projectRoot, dir) => {
-  rimraf(`${projectRoot}/${dir}`, () => {
-    console.log(`${projectRoot}/${dir} removed`);
-  });
-};
-
-
 const migrateComponents = async (command) => {
-  const projectRoot = __dirname.replace('/node_modules/mui-storyblok/cli', '');
-  addDirToRoot(projectRoot, 'storyblok');
+  process.chdir('./node_modules/mui-storyblok/dist');
   await asyncCmd(command);
-  removeDirFromRoot(projectRoot, 'storyblok');
 };
 
 migrateComponents(cmd);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-storyblok",
-  "version": "1.0.85",
+  "version": "1.0.90",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
     "@material-ui/core": "^4.9.4",
     "@material-ui/icons": "^3.0.2",
     "del-cli": "^3.0.1",
+    "dotenv": "^8.2.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "material-ui-audio-player": "^1.1.9",


### PR DESCRIPTION
Hi,

I  recently came across your project and wanted to try it out.
I was unable to use the cmd ```npx migrate-storyblok-components```, it errored because the folder 'node_modules/mui-storyblok/storyblok' did not exist.

I cloned your project and npm link'd it to my client code so I could have a closer look.

I noticed that you had recently added a workaround to enable the npx command to work with the default stroyblok-migrate config. This looks for a 'storyblok' folder at the root of the process dir, I see you tried to copy over the storyblok folder to the users local root.

Slight bug in that as ```const files = fs.readdirSync('node_modules/mui-storyblok/storyblok');``` is run before files have been copied over so does not exist yet.

Rather than just fix that problem. I couldn't help but think that copying and deleting files from the users root folder wasn't such a good idea. If I had a storyblok folder in my root, then it would have been wiped by this command.

So hopefully I have come up with a simpler solution.

I am just using ```process.chdir('./node_modules/mui-storyblok/dist');``` to switch the process dir to the correct context before running the command, now storyblok-migrate can find a ./storyblok folder.

I also added dotenv, as my environment variables with the storyblok auth were not loaded when running your npx command. dotenv loads the env vars from the original executing process dir so they are available in your script.

I think what you have done so far on this project is great. I have many questions, is there somewhere where I can fire over my questions, rather than raising github issues for each of them?

