### PR TITLE
Added CssBaseline to the StoryBlokPage theme provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-storyblok",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "use react and mui to build pages with storyblok",
   "author": "apjames93",
   "license": "MIT",

--- a/src/lib/components/StoryBlokPage/StoryBlokPage.js
+++ b/src/lib/components/StoryBlokPage/StoryBlokPage.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import CssBaseline from '@material-ui/core/CssBaseline';
 import PropTypes from 'prop-types';
 import Grid from '@material-ui/core/Grid';
 import MuiCircularProgress from '../MuiCircularProgress/MuiCircularProgress';
@@ -105,6 +106,7 @@ export class StoryBlokPage extends Component {
         {this.state.error && <span style={{ color: 'red' }}>{this.state.error}</span>}
         {!this.state.loading && (
         <MuiThemeProvider theme={this.state.muiTheme}>
+          <CssBaseline />
           <div className={styles.container}>
             {this.state.story && this.state.story.map((item, index) => (
               <div key={index}>


### PR DESCRIPTION
This component allows the theme to provide a global background-color, layout changes, and typography properties. This will be needed to have a second (dark theme) to toggle between

**Doc refernce**
https://material-ui.com/components/css-baseline/#page
